### PR TITLE
Add community alt_name to CommunityNames.json when it is available

### DIFF
--- a/extract.py
+++ b/extract.py
@@ -321,10 +321,13 @@ if __name__ == "__main__":
     locations = luts.all_locations
     communities = {}
     for index, location in locations.iterrows():
-        communities[location["id"]] = location["name"] + ", " + location["region"]
-    sorted_communities = dict(sorted(communities.items(), key=lambda x: x[1]))
+        community = {"name": location["name"], "region": location["region"]}
+        if location["alt_name"] != "":
+            community["alt_name"] = location["alt_name"]
+        communities[location["id"]] = community
+    sorted_communities = dict(sorted(communities.items(), key=lambda x: x[1]["name"]))
     community_file = open(output_dir + "/" + community_name_file, "w")
-    json.dump(sorted_communities, community_file)
+    json.dump(sorted_communities, community_file, indent=2)
     community_file.close()
 
     # Process each scenario with its resolution, type, and daterang permutations

--- a/luts.py
+++ b/luts.py
@@ -1,25 +1,32 @@
 import pandas as pd
 
 alaska = pd.read_csv(
-    "../geospatial-vector-veracity/vector_data/point/alaska_point_locations.csv"
+    "../geospatial-vector-veracity/vector_data/point/alaska_point_locations.csv",
+    keep_default_na=False,
 )
 alberta = pd.read_csv(
-    "../geospatial-vector-veracity/vector_data/point/alberta_point_locations.csv"
+    "../geospatial-vector-veracity/vector_data/point/alberta_point_locations.csv",
+    keep_default_na=False,
 )
 british_columbia = pd.read_csv(
-    "../geospatial-vector-veracity/vector_data/point/british_columbia_point_locations.csv"
+    "../geospatial-vector-veracity/vector_data/point/british_columbia_point_locations.csv",
+    keep_default_na=False,
 )
 manitoba = pd.read_csv(
-    "../geospatial-vector-veracity/vector_data/point/manitoba_point_locations.csv"
+    "../geospatial-vector-veracity/vector_data/point/manitoba_point_locations.csv",
+    keep_default_na=False,
 )
 nwt = pd.read_csv(
-    "../geospatial-vector-veracity/vector_data/point/northwest_territories_point_locations.csv"
+    "../geospatial-vector-veracity/vector_data/point/northwest_territories_point_locations.csv",
+    keep_default_na=False,
 )
 saskatchewan = pd.read_csv(
-    "../geospatial-vector-veracity/vector_data/point/saskatchewan_point_locations.csv"
+    "../geospatial-vector-veracity/vector_data/point/saskatchewan_point_locations.csv",
+    keep_default_na=False,
 )
 yukon = pd.read_csv(
-    "../geospatial-vector-veracity/vector_data/point/yukon_point_locations.csv"
+    "../geospatial-vector-veracity/vector_data/point/yukon_point_locations.csv",
+    keep_default_na=False,
 )
 non_nwt = pd.concat([alaska, alberta, british_columbia, manitoba, saskatchewan, yukon])
 all_locations = pd.concat(


### PR DESCRIPTION
Closes #2.

This PR restructures the `CommunityNames.json` file that is created near the beginning of the script execution. Community `name` and `region` are now separate JSON fields, and `alt_name` is also included when it is available.

STR, the long way:
- Follow the README to set everything up & run the script.
- Look at `output/CommunityNames.json`.

STR, the short way (recommended!):
- Follow the part of the README where you clone this repo and the geospatial-vector-veracity repo.
- Temporarily comment out this line to prevent processing of GeoTIFFs: https://github.com/ua-snap/cc-data-extraction/blob/63946892ad0a92994d3fcd7d375a0c86060e9b9e/extract.py#L335
- Run the script.
- Look at `output/CommunityNames.json`.