### PR TITLE
Replace "cru32" with "cru322" throughout input files, output files, and code

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ These datasets need to be extracted into an `input` subdirectory with the follow
 
 ```
 input
-├── cru32
+├── cru322
 │   └── 10min
 │       ├── pr
 │       └── tas

--- a/extract.py
+++ b/extract.py
@@ -321,10 +321,13 @@ if __name__ == "__main__":
     locations = luts.all_locations
     communities = {}
     for index, location in locations.iterrows():
-        communities[location["id"]] = location["name"] + ", " + location["region"]
-    sorted_communities = dict(sorted(communities.items(), key=lambda x: x[1]))
+        community = {"name": location["name"], "region": location["region"]}
+        if location["alt_name"] != "":
+            community["alt_name"] = location["alt_name"]
+        communities[location["id"]] = community
+    sorted_communities = dict(sorted(communities.items(), key=lambda x: x[1]["name"]))
     community_file = open(output_dir + "/" + community_name_file, "w")
-    json.dump(sorted_communities, community_file)
+    json.dump(sorted_communities, community_file, indent=2)
     community_file.close()
 
     # Process each scenario with its resolution, type, and daterang permutations

--- a/extract.py
+++ b/extract.py
@@ -107,8 +107,12 @@ def run_extraction(files, communities, scenario, resolution, type, daterange):
             "type": type,
             "scenario": scenario,
             "resolution": resolution,
-            "unit": "C",
         }
+
+        if type == "Temperature":
+            row["unit"] = "C"
+        elif type == "Precipitation":
+            row["unit"] = "mm"
 
         if scenario in ["cru32", "prism"]:
             row["daterange"] = "Historical"

--- a/extract.py
+++ b/extract.py
@@ -114,7 +114,7 @@ def run_extraction(files, communities, scenario, resolution, type, daterange):
         elif type == "Precipitation":
             row["unit"] = "mm"
 
-        if scenario in ["cru32", "prism"]:
+        if scenario in ["cru322", "prism"]:
             row["daterange"] = "Historical"
         else:
             row["daterange"] = "{0}-{1}".format(daterange[0], daterange[1])

--- a/luts.py
+++ b/luts.py
@@ -1,25 +1,32 @@
 import pandas as pd
 
 alaska = pd.read_csv(
-    "../geospatial-vector-veracity/vector_data/point/alaska_point_locations.csv"
+    "../geospatial-vector-veracity/vector_data/point/alaska_point_locations.csv",
+    keep_default_na=False,
 )
 alberta = pd.read_csv(
-    "../geospatial-vector-veracity/vector_data/point/alberta_point_locations.csv"
+    "../geospatial-vector-veracity/vector_data/point/alberta_point_locations.csv",
+    keep_default_na=False,
 )
 british_columbia = pd.read_csv(
-    "../geospatial-vector-veracity/vector_data/point/british_columbia_point_locations.csv"
+    "../geospatial-vector-veracity/vector_data/point/british_columbia_point_locations.csv",
+    keep_default_na=False,
 )
 manitoba = pd.read_csv(
-    "../geospatial-vector-veracity/vector_data/point/manitoba_point_locations.csv"
+    "../geospatial-vector-veracity/vector_data/point/manitoba_point_locations.csv",
+    keep_default_na=False,
 )
 nwt = pd.read_csv(
-    "../geospatial-vector-veracity/vector_data/point/northwest_territories_point_locations.csv"
+    "../geospatial-vector-veracity/vector_data/point/northwest_territories_point_locations.csv",
+    keep_default_na=False,
 )
 saskatchewan = pd.read_csv(
-    "../geospatial-vector-veracity/vector_data/point/saskatchewan_point_locations.csv"
+    "../geospatial-vector-veracity/vector_data/point/saskatchewan_point_locations.csv",
+    keep_default_na=False,
 )
 yukon = pd.read_csv(
-    "../geospatial-vector-veracity/vector_data/point/yukon_point_locations.csv"
+    "../geospatial-vector-veracity/vector_data/point/yukon_point_locations.csv",
+    keep_default_na=False,
 )
 non_nwt = pd.concat([alaska, alberta, british_columbia, manitoba, saskatchewan, yukon])
 all_locations = pd.concat(

--- a/luts.py
+++ b/luts.py
@@ -33,10 +33,10 @@ all_locations = pd.concat(
     [alaska, alberta, british_columbia, manitoba, nwt, saskatchewan, yukon]
 )
 
-scenarios_lu = ["cru32", "prism", "rcp45", "rcp60", "rcp85"]
+scenarios_lu = ["cru322", "prism", "rcp45", "rcp60", "rcp85"]
 
 resolutions_lu = {
-    "cru32": {
+    "cru322": {
         "10min": nwt,
     },
     "prism": {
@@ -56,7 +56,7 @@ resolutions_lu = {
 types_lu = {"tas": "Temperature", "pr": "Precipitation"}
 
 dateranges_lu = {
-    "cru32": [[1961, 1990]],
+    "cru322": [[1961, 1990]],
     "prism": [[1961, 1990]],
     "rcp45": [[2030, 2039], [2060, 2069], [2090, 2099]],
     "rcp60": [[2030, 2039], [2060, 2069], [2090, 2099]],
@@ -64,7 +64,7 @@ dateranges_lu = {
 }
 
 projections_lu = {
-    "cru32": "EPSG:4326",
+    "cru322": "EPSG:4326",
     "prism": "EPSG:3338",
     "rcp45": "EPSG:3338",
     "rcp60": "EPSG:3338",


### PR DESCRIPTION
Closes #5.

This replaces the value `cru32` with `cru322` in the CSV output files for NWT locations (`NT*.csv`) to make it more clear that the data is from CRU TS 3.22.

`cru32` has also been replaced with `cru322` throughout the code, input directory structure, and README for consistency.