### PR TITLE
Add 2k resolution projected temperature min/max values to CSVs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,35 +41,41 @@ These datasets need to be extracted into an `input` subdirectory with the follow
 
 ```
 input
-├── cru322
-│   └── 10min
-│       ├── pr
-│       └── tas
+├── cru32
+│   └── 10min
+│       ├── pr
+│       └── tas
 ├── prism
-│   └── 2km
-│       ├── pr
-│       └── tas
+│   └── 2km
+│       ├── pr
+│       └── tas
 ├── rcp45
-│   ├── 10min
-│   │   ├── pr
-│   │   └── tas
-│   └── 2km
-│       ├── pr
-│       └── tas
+│   ├── 10min
+│   │   ├── pr
+│   │   └── tas
+│   └── 2km
+│       ├── pr
+│       ├── tas
+│       ├── tasmax
+│       └── tasmin
 ├── rcp60
-│   ├── 10min
-│   │   ├── pr
-│   │   └── tas
-│   └── 2km
-│       ├── pr
-│       └── tas
+│   ├── 10min
+│   │   ├── pr
+│   │   └── tas
+│   └── 2km
+│       ├── pr
+│       ├── tas
+│       ├── tasmax
+│       └── tasmin
 └── rcp85
     ├── 10min
-    │   ├── pr
-    │   └── tas
+    │   ├── pr
+    │   └── tas
     └── 2km
         ├── pr
-        └── tas
+        ├── tas
+        ├── tasmax
+        └── tasmin
 ```
 
 ## Run

--- a/pylintrc
+++ b/pylintrc
@@ -5,3 +5,4 @@ disable=E1136,W0511,W0621
 [FORMAT]
 good-names=x,y
 max-args=6
+max-locals=20


### PR DESCRIPTION
Closes #13.

Temperature min/max values have been added to all locations covered by the 2km projected dataset (i.e., all locations except Northwest Territories locations). New columns for min/max have been added to all CSV files, `janMin` and `janMax` (for all months). When a value is not available for the column (in the case of precipitation, historical values, and Northwest Territories locations), the field is simply left blank to avoid bloating the size of the CSV files.