### PR TITLE
Take max of max temperatures, not min of max temperatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ The extract.py script depends on the following datasets:
 
 For the projected datasets, this script uses only the 5-model average. There is no need to download projected data for individual models.
 
+In addition to mean temperature, min/max projected temperature data is availabe at 2km resolution from the "Projected Monthly and Derived Temperature Products - 2km CMIP5/AR5" dataset linked above. For that dataset, download the `tasmin*` and `tasmax*` 5modelAvg ZIP files in addition to the `tas_mean*` 5modelAvg ZIP files, and extract them into their corresponding `tasmin` and `tasmax` subdirectories shown in the directory tree below.
+
 These datasets need to be extracted into an `input` subdirectory with the following structure:
 
 ```

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ These datasets need to be extracted into an `input` subdirectory with the follow
 
 ```
 input
-├── cru32
+├── cru322
 │   └── 10min
 │       ├── pr
 │       └── tas

--- a/extract.py
+++ b/extract.py
@@ -180,7 +180,7 @@ def populate_data(community, month_values, row, variable):
                 row[month_label_mean] = month_mean.round(1)
 
                 if len(max_values) > 0:
-                    row[month_label_max] = max_values.min().round(1)
+                    row[month_label_max] = max_values.max().round(1)
                 else:
                     row[month_label_max] = ""
 


### PR DESCRIPTION
Closes #17.

This PR fixes a copy & paste bug that was taking the minimum of the maximum annual temperatures for each month, instead of the maximum of the maximum annual temperatures.

Testing is a little tricky because this script relies on the geospatial-vector-veracity repository, and the latest version of the geospatial-vector-veracity repository has new community lat/lon points that don't work as well with this script because it has trouble finding data within an acceptable grid distance.

So, to keep things simple and to make sure the list of community CSVs corresponds to the list of selectable communities in the production Community Charts web app, we will use the version of geospatial-vector-veracity that was used when the Community Charts web app was revamped in December 2021. In other words, do this:

```
cd /path/to/geospatial-vector-veracity

# Check out the commit from Dec 3, 2021.
git checkout 240eff0d814bb4a809c8723e71d634cdf350bec0

cd /path/to/cc-data-extraction
git pull --ff-only
git checkout temperature_max_bug
# Follow this repo's README to run the extract script.
```

Once all the input files have been downloaded according to the README, the extract script should finish in about ~45 minutes depending on your laptop/workstation.

To verify that this PR fixes the bug, compare a couple of the CSV files produced by this script vs. their corresponding downloadable CSV files from the production Community Charts web tool: https://snap.uaf.edu/tools/community-charts All values in the monthly max columns should be higher in the output CSV file than what they are in the downloaded CSV file.