### PR TITLE
Update README links to point to new GeoNetwork records

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ pipenv install
 
 The extract.py script depends on the following datasets:
 
-- [Historical Monthly Temperature Products - 10 min CRU TS 3.22](http://ckan.snap.uaf.edu/dataset/historical-monthly-temperature-products-10-min-cru-ts-3-22)
-- [Historical Monthly Precipitation Products - 10 min CRU TS 3.22](http://ckan.snap.uaf.edu/dataset/historical-monthly-precipitation-products-10-min-cru-ts-3-22)
-- [PRISM 1961-1990 Climatologies](http://ckan.snap.uaf.edu/dataset/prism-1961-1990-climatologies)
-- [Projected Monthly and Derived Temperature Products - 2km CMIP5/AR5](http://ckan.snap.uaf.edu/dataset/projected-monthly-and-derived-temperature-products-2km-cmip5-ar5)
-- [Projected Monthly and Derived Precipitation Products - 2km CMIP5/AR5](http://ckan.snap.uaf.edu/dataset/projected-monthly-and-derived-precipitation-products-2km-cmip5-ar5)
-- [Projected Monthly Temperature Products - 10 min CMIP5/AR5](http://ckan.snap.uaf.edu/dataset/projected-monthly-temperature-products-10-min-cmip5-ar5)
-- [Projected Monthly Precipitation Products - 10 min CMIP5/AR5](http://ckan.snap.uaf.edu/dataset/projected-monthly-precipitation-products-10-min-cmip5-ar5)
+- [Historical Monthly Temperature Products - 10 min CRU TS 3.22](https://catalog.snap.uaf.edu/geonetwork/srv/eng/catalog.search#/metadata/38154af5-c99a-42f9-a240-6ece4f8484a2)
+- [Historical Monthly Precipitation Products - 10 min CRU TS 3.22](https://catalog.snap.uaf.edu/geonetwork/srv/eng/catalog.search#/metadata/be387bf7-9018-4376-a3d2-97ba6441a30b)
+- [PRISM 1961-1990 Climatologies](https://catalog.snap.uaf.edu/geonetwork/srv/eng/catalog.search#/metadata/0e8e42f7-6774-4d35-a7b3-4a82f8b48e00)
+- [Projected Monthly and Derived Temperature Products - 2km CMIP5/AR5](https://catalog.snap.uaf.edu/geonetwork/srv/eng/catalog.search#/metadata/ba834996-ad15-4785-9b43-ef2af86a5ad9)
+- [Projected Monthly and Derived Precipitation Products - 2km CMIP5/AR5](https://catalog.snap.uaf.edu/geonetwork/srv/eng/catalog.search#/metadata/f44595c8-5384-4c02-9ab4-f7a9c43e92eb)
+- [Projected Monthly Temperature Products - 10 min CMIP5/AR5](https://catalog.snap.uaf.edu/geonetwork/srv/eng/catalog.search#/metadata/815c6708-b6cf-4a46-b5c8-344851063117)
+- [Projected Monthly Precipitation Products - 10 min CMIP5/AR5](https://catalog.snap.uaf.edu/geonetwork/srv/eng/catalog.search#/metadata/0de55611-6d88-4c21-9894-95c22b404433)
 
 For the projected datasets, this script uses only the 5-model average. There is no need to download projected data for individual models.
 


### PR DESCRIPTION
Closes #20.

This PR simply updates the input dataset links in the README to point to their new locations in GeoNetwork rather than being redirected from old CKAN URLs, or broken in the case of the PRISM dataset link.

To test, make sure the input dataset links in the README work and link to what they claim to link to.